### PR TITLE
Make integers unsigned before base convert.

### DIFF
--- a/murmurhash3.php
+++ b/murmurhash3.php
@@ -53,5 +53,7 @@ function murmurhash3_int($key,$seed=0){
 }
 
 function murmurhash3($key,$seed=0){
-  return base_convert(murmurhash3_int($key,$seed),10,32);
+  $hash = murmurhash3_int($key,$seed);
+
+  return base_convert(sprintf("%u\n", $hash),10,32);
 }


### PR DESCRIPTION
Problem: On 32-bit systems, murmurhash3_int can return negative integers which cause incorrect hash values to be returned from murmurhash3.

Solution: Use sprintf and the %u modifier to convert all integers to unsigned integers before performing the base conversion.

Reference: See warning in PHP crc32 documentation: http://php.net/manual/en/function.crc32.php

Potential problem: If users have been using this function on 32 bit systems, many of their hashes are actually incorrect. This PR will fix the problem, but could cause hash value inconsistency with hashes made before the PR. One solution would be to pull the 32-bit logic out to a separate function so that existing users would have to explicitly change the way they use the hash in their code base. If this is desired, I will change and push a new commit.