### PR TITLE
Fix docblock

### DIFF
--- a/src/lastguest/Murmur.php
+++ b/src/lastguest/Murmur.php
@@ -18,8 +18,8 @@ class Murmur {
 
   /**
    * @param  string $key   Text to hash.
-   * @param  number $seed  Positive integer only
-   * @return number 32-bit positive integer hash
+   * @param  integer $seed  Positive integer only
+   * @return integer 32-bit positive integer hash
    */
   public static function hash3_int(string $key, int $seed=0) : int {
     $key  = array_values(unpack('C*', $key));
@@ -61,7 +61,7 @@ class Murmur {
 
   /**
    * @param  string $key   Text to hash.
-   * @param  number $seed  Positive integer only
+   * @param  integer $seed  Positive integer only
    * @return string
    */
   public static function hash3(string $key, int $seed=0) : string {


### PR DESCRIPTION
As per Docblock standard there is currently no "number" type.
https://phpstan.org/writing-php-code/phpdoc-types

Some static analysis tools like psalm will mark this as an error.